### PR TITLE
[Experimental] Delete node call

### DIFF
--- a/framework/command/NodeCallCommandStrategy.php
+++ b/framework/command/NodeCallCommandStrategy.php
@@ -111,6 +111,8 @@ class NodeCallCommandStrategy implements ICommandStrategy
         {
             $this->statusCommand->Process($this->eventData);
             $this->statusCommand->SendResponse();
+            
+            $this->slackApi->DeleteMessage($this->eventData['ts'], $this->eventData['channel']);
         }
         
         unset($this->response);

--- a/framework/slack/ISlackApi.php
+++ b/framework/slack/ISlackApi.php
@@ -12,4 +12,5 @@ interface ISlackApi
     public function GetGroupMessagesSince($ts, $channel);
     public function SetTopic($topic, $channel);
     public function CheckPresence($user);
+    public function DeleteMessage($timestamp, $channel);
 }

--- a/framework/slack/NullSlackApi.php
+++ b/framework/slack/NullSlackApi.php
@@ -20,6 +20,7 @@ class NullSlackApi implements ISlackApi
     private $GroupHistoryApiUri = 'https://slack.com/api/channels.history';
     private $TopicApiUri = 'https://slack.com/api/channels.setTopic';
     private $CheckPresenceUri = 'https://slack.com/api/users.getPresence';
+    private $DeleteMessageApiUri = 'https://slack.com/api/chat.delete';
 
     public function SendMessage($message, $attachments = null, $channel = 'test2')
     {
@@ -75,6 +76,16 @@ class NullSlackApi implements ISlackApi
         $queryString = "token=" . \Config::$BotOAuthToken;
         $queryString .= "&user=" . $user;
         $uri = $this->CheckPresenceUri . "?" . $queryString;
+        var_dump($uri);
+        return null;
+    }
+    
+    public function DeleteMessage($timestamp, $channel)
+    {
+        $queryString = "token=" . \Config::$BotUserOAuthToken;
+        $queryString .= "&channel=" . $channel;
+        $queryString .= "&ts=" . $timestamp;
+        $uri = $this->DeleteMessageApiUri . "?" . $queryString;
         var_dump($uri);
         return null;
     }

--- a/framework/slack/SlackApi.php
+++ b/framework/slack/SlackApi.php
@@ -20,8 +20,10 @@ class SlackApi implements ISlackApi
     private $GroupHistoryApiUri = 'https://slack.com/api/channels.history';
     private $TopicApiUri = 'https://slack.com/api/channels.setTopic';
     private $CheckPresenceUri = 'https://slack.com/api/users.getPresence';
+    private $DeleteMessageApiUri = 'https://slack.com/api/chat.delete';
 
-    public function SendMessage($message, $attachments = null, $channel = 'test2')
+    public function SendMessage($message, $attachments = null,
+                                $channel = 'test2')
     {
         $queryString = "token=" . \Config::$BotUserOAuthToken;
         $queryString .= "&channel=" . $channel;
@@ -83,7 +85,7 @@ class SlackApi implements ISlackApi
 
         return $response;
     }
-    
+
     public function CheckPresence($user)
     {
         $queryString = "token=" . \Config::$BotOAuthToken;
@@ -101,9 +103,17 @@ class SlackApi implements ISlackApi
         
     }
 
-    public function DeleteMessage()
+    public function DeleteMessage($timestamp, $channel)
     {
-        
+        $queryString = "token=" . \Config::$BotUserOAuthToken;
+        $queryString .= "&channel=" . $channel;
+        $queryString .= "&ts=" . $timestamp;
+        $uri = $this->DeleteMessageApiUri . "?" . $queryString;
+        $response = \Httpful\Request::post($uri)
+                ->addHeader('Content-Type', 'text/plain; charset=utf-8')
+                ->send();
+
+        return $response;
     }
 
 }

--- a/framework/slack/SlackApi.php
+++ b/framework/slack/SlackApi.php
@@ -105,15 +105,13 @@ class SlackApi implements ISlackApi
 
     public function DeleteMessage($timestamp, $channel)
     {
-        $queryString = "token=" . \Config::$BotUserOAuthToken;
+        $queryString = "token=" . \Config::$BotOAuthToken;
         $queryString .= "&channel=" . $channel;
         $queryString .= "&ts=" . $timestamp;
         $uri = $this->DeleteMessageApiUri . "?" . $queryString;
-        error_log($uri);
         $response = \Httpful\Request::post($uri)
                 ->addHeader('Content-Type', 'text/plain; charset=utf-8')
                 ->send();
-        error_log($response);
         return $response;
     }
 

--- a/framework/slack/SlackApi.php
+++ b/framework/slack/SlackApi.php
@@ -109,10 +109,11 @@ class SlackApi implements ISlackApi
         $queryString .= "&channel=" . $channel;
         $queryString .= "&ts=" . $timestamp;
         $uri = $this->DeleteMessageApiUri . "?" . $queryString;
+        error_log($uri);
         $response = \Httpful\Request::post($uri)
                 ->addHeader('Content-Type', 'text/plain; charset=utf-8')
                 ->send();
-
+        error_log($response);
         return $response;
     }
 

--- a/tests/framework/command/NodeCallCommandStrategyTest.php
+++ b/tests/framework/command/NodeCallCommandStrategyTest.php
@@ -77,6 +77,7 @@ class NodeCallCommandStrategyTest extends TestCaseBase
             'channel' => 'TESTCHANNEL',
             'text' => '1.2',
             'user' => 'TEST USER',
+            'ts' => 123.123123,
         );
 
         $this->statusCommandMock->expects($this->once())
@@ -105,6 +106,7 @@ class NodeCallCommandStrategyTest extends TestCaseBase
             'channel' => 'TESTCHANNEL',
             'text' => '1.2   ',
             'user' => 'TEST USER',
+            'ts' => 123.123123,
         );
 
         $this->statusCommandMock->expects($this->once())
@@ -133,6 +135,7 @@ class NodeCallCommandStrategyTest extends TestCaseBase
             'channel' => 'TESTCHANNEL',
             'text' => '1.2 <@UD1A3S>',
             'user' => 'TEST USER',
+            'ts' => 123.123123,
         );
 
         $this->statusCommandMock->expects($this->once())
@@ -161,6 +164,7 @@ class NodeCallCommandStrategyTest extends TestCaseBase
             'channel' => 'TESTCHANNEL',
             'text' => '1.2 <@UD1A3S>    ',
             'user' => 'TEST USER',
+            'ts' => 123.123123,
         );
 
         $this->statusCommandMock->expects($this->once())


### PR DESCRIPTION
After calling a node, if Jarvis accepts and assigns you, the original call message will be deleted to prevent the table from being pushed up.