### PR TITLE
File deletion

### DIFF
--- a/AutoloadBootstrapper.php
+++ b/AutoloadBootstrapper.php
@@ -57,6 +57,7 @@ require_once __DIR__ . '/framework' . '/command' . '/SummaryHistoryCommandStrate
 require_once __DIR__ . '/framework' . '/command' . '/ArchiveUserCommandStrategy.php';
 require_once __DIR__ . '/framework' . '/command' . '/UserListCommandStrategy.php';
 require_once __DIR__ . '/framework' . '/system' . '/FileListCommandStrategy.php';
+require_once __DIR__ . '/framework' . '/system' . '/DeleteFileCommandStrategy.php';
 
 require_once __DIR__ . '/framework' . '/process' . '/ProcessManager.php';
 

--- a/AutoloadBootstrapper.php
+++ b/AutoloadBootstrapper.php
@@ -56,7 +56,7 @@ require_once __DIR__ . '/framework' . '/command' . '/TrainingModeCommandStrategy
 require_once __DIR__ . '/framework' . '/command' . '/SummaryHistoryCommandStrategy.php';
 require_once __DIR__ . '/framework' . '/command' . '/ArchiveUserCommandStrategy.php';
 require_once __DIR__ . '/framework' . '/command' . '/UserListCommandStrategy.php';
-require_once __DIR__ . '/framework' . '/command' . '/FileListCommandStrategy.php';
+require_once __DIR__ . '/framework' . '/system' . '/FileListCommandStrategy.php';
 
 require_once __DIR__ . '/framework' . '/process' . '/ProcessManager.php';
 

--- a/AutoloadBootstrapper.php
+++ b/AutoloadBootstrapper.php
@@ -56,5 +56,11 @@ require_once __DIR__ . '/framework' . '/command' . '/TrainingModeCommandStrategy
 require_once __DIR__ . '/framework' . '/command' . '/SummaryHistoryCommandStrategy.php';
 require_once __DIR__ . '/framework' . '/command' . '/ArchiveUserCommandStrategy.php';
 require_once __DIR__ . '/framework' . '/command' . '/UserListCommandStrategy.php';
+require_once __DIR__ . '/framework' . '/command' . '/FileListCommandStrategy.php';
 
 require_once __DIR__ . '/framework' . '/process' . '/ProcessManager.php';
+
+require_once __DIR__ . '/framework' . '/system' . '/SlackFileManager.php';
+require_once __DIR__ . '/framework' . '/system' . '/models' . '/FileInfoModel.php';
+require_once __DIR__ . '/framework' . '/system' . '/models' . '/FileListModel.php';
+require_once __DIR__ . '/framework' . '/system' . '/models' . '/PagingModel.php';

--- a/app/config.php
+++ b/app/config.php
@@ -59,6 +59,8 @@ return [
                 ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
                 DI\object('framework\command\UserListCommandStrategy')
                 ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
+                DI\object('framework\system\FileListCommandStrategy')
+                ->constructor(DI\get('SlackFileManager'), DI\get('ISlackApi')),
     ],
     'CommandStrategyFactory' => DI\factory(function($strategies)
     {

--- a/app/config.php
+++ b/app/config.php
@@ -61,6 +61,8 @@ return [
                 ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
                 DI\object('framework\system\FileListCommandStrategy')
                 ->constructor(DI\get('SlackFileManager'), DI\get('ISlackApi')),
+                DI\object('framework\system\DeleteFileCommandStrategy')
+                ->constructor(DI\get('SlackFileManager'), DI\get('ISlackApi')),
     ],
     'CommandStrategyFactory' => DI\factory(function($strategies)
     {

--- a/app/config.php
+++ b/app/config.php
@@ -27,6 +27,8 @@ return [
             ->constructor(DI\get('CoreRepository'), DI\get('ConquestRepository'), DI\get('ZoneRepository'), DI\get('StrikeRepository'), DI\get('ISlackApi')),
     'ConquestManager' => DI\object('framework\conquest\ConquestManager')
             ->constructor(DI\get('ConquestRepository'), DI\get('ZoneRepository'), DI\get('NodeRepository'), DI\get('StrikeRepository')),
+    'SlackFileManager' => DI\object('framework\system\SlackFileManager')
+            ->constructor(DI\get('ISlackApi')),
     'framework\command\ICommandStrategy' => [
                 DI\object('framework\command\InitCommandStrategy')
                 ->constructor(DI\get('CoreRepository'), DI\get('ISlackApi')),

--- a/framework/slack/ISlackApi.php
+++ b/framework/slack/ISlackApi.php
@@ -13,4 +13,5 @@ interface ISlackApi
     public function SetTopic($topic, $channel);
     public function CheckPresence($user);
     public function DeleteMessage($timestamp, $channel);
+    public function GetFileList($channel=null, $page=1, $ts_from=0, $ts_to='now', $types='all', $user=null);
 }

--- a/framework/slack/ISlackApi.php
+++ b/framework/slack/ISlackApi.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace framework\slack;
 
 /**
@@ -7,11 +8,15 @@ namespace framework\slack;
  */
 interface ISlackApi
 {
-    public function SendMessage($message, $attachments = null, $channel = 'test2');
+    public function SendMessage($message, $attachments = null,
+                                $channel = 'test2');
     public function UpdateMessage($ts, $channel, $message, $attachments = []);
     public function GetGroupMessagesSince($ts, $channel);
     public function SetTopic($topic, $channel);
     public function CheckPresence($user);
     public function DeleteMessage($timestamp, $channel);
-    public function GetFileList($channel=null, $page=1, $ts_from=0, $ts_to='now', $types='all', $user=null);
+    public function GetFileList($channel = null, $page = 1, $ts_from = 0,
+                                $ts_to = 'now', $types = 'all', $count,
+                                $user = null);
+    public function DeleteFile($file);
 }

--- a/framework/slack/ISlackApi.php
+++ b/framework/slack/ISlackApi.php
@@ -16,7 +16,7 @@ interface ISlackApi
     public function CheckPresence($user);
     public function DeleteMessage($timestamp, $channel);
     public function GetFileList($channel = null, $page = 1, $ts_from = 0,
-                                $ts_to = 'now', $types = 'all', $count,
+                                $ts_to = 'now', $types = 'all', $count=100,
                                 $user = null);
     public function DeleteFile($file);
 }

--- a/framework/slack/NullSlackApi.php
+++ b/framework/slack/NullSlackApi.php
@@ -22,7 +22,8 @@ class NullSlackApi implements ISlackApi
     private $CheckPresenceUri = 'https://slack.com/api/users.getPresence';
     private $DeleteMessageApiUri = 'https://slack.com/api/chat.delete';
 
-    public function SendMessage($message, $attachments = null, $channel = 'test2')
+    public function SendMessage($message, $attachments = null,
+                                $channel = 'test2')
     {
         $queryString = "token=" . \Config::$BotUserOAuthToken;
         $queryString .= "&channel=" . $channel;
@@ -79,7 +80,7 @@ class NullSlackApi implements ISlackApi
         var_dump($uri);
         return null;
     }
-    
+
     public function DeleteMessage($timestamp, $channel)
     {
         $queryString = "token=" . \Config::$BotUserOAuthToken;
@@ -91,7 +92,13 @@ class NullSlackApi implements ISlackApi
     }
 
     public function GetFileList($channel = null, $page = 1, $ts_from = 0,
-                             $ts_to = 'now', $types = 'all', $user = null)
+                                $ts_to = 'now', $types = 'all', $count = 100,
+                                $user = null)
+    {
+        return null;
+    }
+
+    public function DeleteFile($file)
     {
         return null;
     }

--- a/framework/slack/NullSlackApi.php
+++ b/framework/slack/NullSlackApi.php
@@ -90,4 +90,10 @@ class NullSlackApi implements ISlackApi
         return null;
     }
 
+    public function GetFileList($channel = null, $page = 1, $ts_from = 0,
+                             $ts_to = 'now', $types = 'all', $user = null)
+    {
+        return null;
+    }
+
 }

--- a/framework/slack/SlackApi.php
+++ b/framework/slack/SlackApi.php
@@ -127,6 +127,7 @@ class SlackApi implements ISlackApi
         $queryString .= "&ts_from=" . $ts_from;
         $queryString .= "&ts_to=" . $ts_to;
         $queryString .= "&types=" . $types;
+        $queryString .= "&count=1000";
         if ($user != null)
         {
             $queryString .= "&user=" . $user;

--- a/framework/slack/SlackApi.php
+++ b/framework/slack/SlackApi.php
@@ -22,6 +22,7 @@ class SlackApi implements ISlackApi
     private $CheckPresenceUri = 'https://slack.com/api/users.getPresence';
     private $DeleteMessageApiUri = 'https://slack.com/api/chat.delete';
     private $FileListApiUri = 'https://slack.com/api/files.list';
+    private $FileDeleteApiUri = 'https://slack.com/api/files.delete';
 
     public function SendMessage($message, $attachments = null,
                                 $channel = 'test2')
@@ -116,7 +117,7 @@ class SlackApi implements ISlackApi
         return $response;
     }
     
-    public function GetFileList($channel=null, $page=1, $ts_from=0, $ts_to='now', $types='all', $user=null)
+    public function GetFileList($channel=null, $page=1, $ts_from=0, $ts_to='now', $types='all', $count=100, $user=null)
     {
         $queryString = "token=" . \Config::$BotOAuthToken;
         if ($channel != null)
@@ -127,7 +128,7 @@ class SlackApi implements ISlackApi
         $queryString .= "&ts_from=" . $ts_from;
         $queryString .= "&ts_to=" . $ts_to;
         $queryString .= "&types=" . $types;
-        $queryString .= "&count=1000";
+        $queryString .= "&count=" . $count;
         if ($user != null)
         {
             $queryString .= "&user=" . $user;
@@ -142,4 +143,17 @@ class SlackApi implements ISlackApi
         return $response;
     }
 
+    public function DeleteFile($file)
+    {
+        $queryString = "token=" . \Config::$BotOAuthToken;
+        $queryString .= "&file=" . $file;
+        
+        $uri = $this->FileDeleteApiUri . "?" . $queryString;
+        $response = \Httpful\Request::get($uri)
+                ->expectsJson()
+                ->addHeader('Content-Type', 'text/plain; charset=utf-8')
+                ->send();
+
+        return $response;
+    }
 }

--- a/framework/slack/SlackApi.php
+++ b/framework/slack/SlackApi.php
@@ -21,6 +21,7 @@ class SlackApi implements ISlackApi
     private $TopicApiUri = 'https://slack.com/api/channels.setTopic';
     private $CheckPresenceUri = 'https://slack.com/api/users.getPresence';
     private $DeleteMessageApiUri = 'https://slack.com/api/chat.delete';
+    private $FileListApiUri = 'https://slack.com/api/files.list';
 
     public function SendMessage($message, $attachments = null,
                                 $channel = 'test2')
@@ -112,6 +113,31 @@ class SlackApi implements ISlackApi
         $response = \Httpful\Request::post($uri)
                 ->addHeader('Content-Type', 'text/plain; charset=utf-8')
                 ->send();
+        return $response;
+    }
+    
+    public function GetFileList($channel=null, $page=1, $ts_from=0, $ts_to='now', $types='all', $user=null)
+    {
+        $queryString = "token=" . \Config::$BotOAuthToken;
+        if ($channel != null)
+        {
+            $queryString .= "&channel=" . $channel;
+        }
+        $queryString .= "&page=" . $page;
+        $queryString .= "&ts_from=" . $ts_from;
+        $queryString .= "&ts_to=" . $ts_to;
+        $queryString .= "&types=" . $types;
+        if ($user != null)
+        {
+            $queryString .= "&user=" . $user;
+        }
+        
+        $uri = $this->FileListApiUri . "?" . $queryString;
+        $response = \Httpful\Request::get($uri)
+                ->expectsJson()
+                ->addHeader('Content-Type', 'text/plain; charset=utf-8')
+                ->send();
+
         return $response;
     }
 

--- a/framework/system/DeleteFileCommandStrategy.php
+++ b/framework/system/DeleteFileCommandStrategy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace framework\system;
+
+use framework\command\ICommandStrategy;
+use framework\system\SlackFileManager;
+use framework\slack\ISlackApi;
+use DateTime;
+/**
+ * Description of DeleteFileCommandStrategy
+ *
+ * @author chris
+ */
+class DeleteFileCommandStrategy implements ICommandStrategy
+{
+    const Regex = '/(file delete oldest)(?:\s)(\d+)/i';
+
+    private $eventData;
+    private $fileManager;
+    private $slackApi;
+    private $response;
+    private $attachments;
+
+    public function __construct(SlackFileManager $fileManager,
+                                ISlackApi $slackApi)
+    {
+        $this->slackApi = $slackApi;
+        $this->fileManager = $fileManager;
+    }
+
+    public function IsJarvisCommand()
+    {
+        return true;
+    }
+
+    public function IsSupportedRequest($text)
+    {
+        return preg_match(DeleteFileCommandStrategy::Regex, $text);
+    }
+
+    public function Process($payload)
+    {
+        $this->eventData = $payload;
+        $data = $payload['text'];
+        $matches = [];
+        if (!preg_match(DeleteFileCommandStrategy::Regex, $data, $matches))
+        {
+            return;
+        }
+
+        $amount = $matches[2];
+        $dateTime = new DateTime();
+        $dateTime->modify('-3 month');
+        
+        $warningMessage = "Attempting to delete *" . $amount . "* images.  This may take some time during which I will be unresponsive.";
+        $this->slackApi->SendMessage($warningMessage, null, $this->eventData['channel']);
+        
+        $this->fileManager->DeleteOldImages($dateTime, $amount);        
+        $this->response = "I have succesfully removed *" . $amount . "* files!  Pinned or starred items have not been affected.";
+    }
+
+    public function SendResponse()
+    {
+        $this->slackApi->SendMessage($this->response, $this->attachments, $this->eventData['channel']);
+        unset($this->response);
+        unset($this->attachments);
+        unset($this->eventData);
+    }
+}

--- a/framework/system/DeleteFileCommandStrategy.php
+++ b/framework/system/DeleteFileCommandStrategy.php
@@ -49,6 +49,12 @@ class DeleteFileCommandStrategy implements ICommandStrategy
         }
 
         $amount = $matches[2];
+        if ($amount > 100)
+        {
+            $this->response = "To prevent systems locking up, I must insist file deletion be less than 100 at a time.";
+            return;
+        }
+        
         $dateTime = new DateTime();
         $dateTime->modify('-3 month');
         

--- a/framework/system/FileListCommandStrategy.php
+++ b/framework/system/FileListCommandStrategy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace framework\command;
+namespace framework\system;
 
 use framework\system\SlackFileManager;
 use framework\slack\ISlackApi;

--- a/framework/system/FileListCommandStrategy.php
+++ b/framework/system/FileListCommandStrategy.php
@@ -2,6 +2,7 @@
 
 namespace framework\system;
 
+use framework\command\ICommandStrategy;
 use framework\system\SlackFileManager;
 use framework\slack\ISlackApi;
 use DateTime;

--- a/framework/system/FileListCommandStrategy.php
+++ b/framework/system/FileListCommandStrategy.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace framework\command;
+
+use framework\system\SlackFileManager;
+use framework\slack\ISlackApi;
+use DateTime;
+
+class FileListCommandStrategy implements ICommandStrategy
+{
+    const Regex = '/(file) (list)/i';
+
+    private $eventData;
+    private $fileManager;
+    private $slackApi;
+    private $response;
+    private $attachments;
+
+    public function __construct(SlackFileManager $fileManager,
+                                ISlackApi $slackApi)
+    {
+        $this->slackApi = $slackApi;
+        $this->fileManager = $fileManager;
+    }
+
+    public function IsJarvisCommand()
+    {
+        return true;
+    }
+
+    public function IsSupportedRequest($text)
+    {
+        return preg_match(UserListCommandStrategy::Regex, $text);
+    }
+
+    public function Process($payload)
+    {
+        $this->eventData = $payload;
+
+        $dateTime = new DateTime();
+        $dateTime->modify('-3 month');
+        $fileList = $this->fileManager->GetFileListBefore($dateTime);
+
+        $fields = array();
+        $message = "Slack contains " . $fileList->paging->total . " images older than " . $dateTime->format('Y/m/d') . "\n";
+
+        $size = 0;
+        foreach ($fileList->files as $file)
+        {
+            $size = $size + $file->size;
+        }
+
+        $message .= "This represents a total of  " . $this->FormatBytes($size);
+
+        array_push($fields, array(
+            'title' => 'File Summary',
+            'value' => $message,
+        ));
+
+        $this->attachments = array();
+        array_push($this->attachments, array(
+            'color' => "#FDC528",
+            'text' => '',
+            'fields' => $fields,
+            'mrkdwn_in' => ["fields"]
+        ));
+    }
+
+    public function SendResponse()
+    {
+        $this->slackApi->SendMessage($this->response, $this->attachments, $this->eventData['channel']);
+        unset($this->response);
+        unset($this->attachments);
+        unset($this->eventData);
+    }
+
+    private function FormatBytes($value, $precision = 2)
+    {
+        $units = array('B', 'KB', 'MB', 'GB', 'TB');
+
+        $bytes = max($value, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, count($units) - 1);
+        $bytes /= pow(1024, $pow);
+
+        return round($bytes, $precision) . ' ' . $units[$pow];
+    }
+
+}

--- a/framework/system/FileListCommandStrategy.php
+++ b/framework/system/FileListCommandStrategy.php
@@ -40,7 +40,7 @@ class FileListCommandStrategy implements ICommandStrategy
 
         $dateTime = new DateTime();
         $dateTime->modify('-3 month');
-        $fileList = $this->fileManager->GetFileListBefore($dateTime);
+        $fileList = $this->fileManager->GetImagesListBefore($dateTime);
 
         $fields = array();
         $message = "Slack contains " . $fileList->paging->total . " images older than " . $dateTime->format('Y/m/d') . "\n";

--- a/framework/system/FileListCommandStrategy.php
+++ b/framework/system/FileListCommandStrategy.php
@@ -43,7 +43,8 @@ class FileListCommandStrategy implements ICommandStrategy
         $fileList = $this->fileManager->GetImagesListBefore($dateTime);
 
         $fields = array();
-        $message = "Slack contains " . $fileList->paging->total . " images older than " . $dateTime->format('Y/m/d') . "\n";
+        $message = "Slack contains " . $fileList->paging->total . " images older than *" . $dateTime->format('Y/m/d') . "*. "
+                . "I have not counted any pinned or starred items.\n";
 
         $size = 0;
         foreach ($fileList->files as $file)
@@ -51,7 +52,7 @@ class FileListCommandStrategy implements ICommandStrategy
             $size = $size + $file->size;
         }
 
-        $message .= "This represents a total of  " . $this->FormatBytes($size);
+        $message .= "This represents a total of *" . $this->FormatBytes($size) . "*";
 
         array_push($fields, array(
             'title' => 'File Summary',

--- a/framework/system/FileListCommandStrategy.php
+++ b/framework/system/FileListCommandStrategy.php
@@ -31,7 +31,7 @@ class FileListCommandStrategy implements ICommandStrategy
 
     public function IsSupportedRequest($text)
     {
-        return preg_match(UserListCommandStrategy::Regex, $text);
+        return preg_match(FileListCommandStrategy::Regex, $text);
     }
 
     public function Process($payload)

--- a/framework/system/SlackFileManager.php
+++ b/framework/system/SlackFileManager.php
@@ -47,14 +47,14 @@ class SlackFileManager
     public function GetImagesListBefore(DateTime $dateTime)
     {
         $toReturn = new FileListModel();
-        $response = $this->slackApi->GetFileList(null, 1, 0, $dateTime->getTimestamp(), 'images');
+        $response = $this->slackApi->GetFileList(null, 1, 0, $dateTime->getTimestamp(), 'images', 1000);
         
         $toReturn->files = $this->ParseFiles($response->body);
         $toReturn->paging = $this->ParsePaging($response->body);
         
         for ($i=2; $i <= $toReturn->paging->pages; $i++)
         {
-            $response = $this->slackApi->GetFileList(null, $i, 0, $dateTime->getTimestamp(), 'images');
+            $response = $this->slackApi->GetFileList(null, $i, 0, $dateTime->getTimestamp(), 'images', 1000);
             array_merge($toReturn->files, $this->ParseFiles($response->body));
         }        
         return $toReturn;

--- a/framework/system/SlackFileManager.php
+++ b/framework/system/SlackFileManager.php
@@ -40,6 +40,12 @@ class SlackFileManager
         
         $toReturn->files = $this->ParseFiles($response->body);
         $toReturn->paging = $this->ParsePaging($response->body);
+        
+        for ($i=2; $i <= $toReturn->paging->pages; $i++)
+        {
+            $response = $this->slackApi->GetFileList(null, $i, 0, $dateTime->getTimestamp(), 'images');
+            array_merge($toReturn->files, $this->ParseFiles($response->body));
+        }        
         return $toReturn;
     }
 

--- a/framework/system/SlackFileManager.php
+++ b/framework/system/SlackFileManager.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace framework\system;
+
+use framework\slack\ISlackApi;
+use framwork\system\models\FileListModel;
+use framwork\system\models\FileInfoModel;
+use framwork\system\models\PagingModel;
+use DateTime;
+
+/**
+ * Description of SlackFileManager
+ *
+ * @author chris
+ */
+class SlackFileManager
+{
+    /** @var ISlackApi */
+    private $slackApi;
+
+    public function __construct(ISlackApi $slackApi)
+    {
+        $this->slackApi = $slackApi;
+    }
+
+    public function GetFileList()
+    {
+        $toReturn = new FileListModel();
+        $response = $this->slackApi->GetFileList();
+        
+        $toReturn->files = $this->ParseFiles($response->body);
+        $toReturn->paging = $this->ParsePaging($response->body);
+        return $toReturn;
+    }
+    
+    public function GetImagesListBefore(DateTime $dateTime)
+    {
+        $toReturn = new FileListModel();
+        $response = $this->slackApi->GetFileList(null, 1, 0, $dateTime->getTimestamp(), 'images');
+        
+        $toReturn->files = $this->ParseFiles($response->body);
+        $toReturn->paging = $this->ParsePaging($response->body);
+        return $toReturn;
+    }
+
+    private function ParseFiles($body)
+    {
+        $toReturn = array();
+        foreach ($body->files as $file)
+        {
+            $fileInfo = new FileInfoModel();
+            $fileInfo->num_stars = isset($file->num_stars) ? $file->num_stars : 0;
+            $fileInfo->pinned_to = isset($file->pinned_to) ? $file->pinned_to : [];
+            if (sizeof($fileInfo->pinned_to) > 0 || $fileInfo->num_stars > 0)
+            {
+                continue;
+            }
+            
+            $fileInfo->id = $file->id;
+            $fileInfo->name = $file->name;
+            $fileInfo->timestamp = $file->timestamp;
+            $fileInfo->filetype = $file->filetype;
+            $fileInfo->size = $file->size;
+            $fileInfo->url_private = $file->url_private;
+            $fileInfo->user = $file->user;            
+            array_push($toReturn, $fileInfo);
+        }
+        return $toReturn;
+    }
+    
+    private function ParsePaging($body)
+    {
+        $toReturn = new PagingModel();
+        $toReturn->count = $body->paging->count;
+        $toReturn->total = $body->paging->total;
+        $toReturn->page = $body->paging->page;
+        $toReturn->pages = $body->paging->pages;
+        return $toReturn;
+    }
+}

--- a/framework/system/SlackFileManager.php
+++ b/framework/system/SlackFileManager.php
@@ -22,6 +22,17 @@ class SlackFileManager
     {
         $this->slackApi = $slackApi;
     }
+    
+    public function DeleteOldImages(DateTime $dateTime, $amount)
+    {
+        $response = $this->slackApi->GetFileList(null, 1, 0, $dateTime->getTimestamp(), 'images', $amount);
+        $files = $this->ParseFiles($response->body);
+        
+        foreach ($files as $file)
+        {
+            $this->slackApi->DeleteFile($file->id);
+        }
+    }
 
     public function GetFileList()
     {

--- a/framework/system/models/FileInfoModel.php
+++ b/framework/system/models/FileInfoModel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace framwork\system\models;
+
+/**
+ * Description of FileInfoModel
+ *
+ * @author chris
+ */
+class FileInfoModel
+{
+    public $id;
+    public $name;
+    public $url_private;
+    public $user;
+    public $size;
+    public $filetype;
+    public $timestamp;
+    public $num_stars;
+    public $pinned_to;
+}

--- a/framework/system/models/FileListModel.php
+++ b/framework/system/models/FileListModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace framwork\system\models;
+
+/**
+ * Description of FileListModel
+ *
+ * @author chris
+ */
+class FileListModel
+{
+    public $files;
+    /** @var PagingModel */
+    public $paging;
+}

--- a/framework/system/models/PagingModel.php
+++ b/framework/system/models/PagingModel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace framwork\system\models;
+
+/**
+ * Description of PagingModel
+ *
+ * @author chris
+ */
+class PagingModel
+{
+    public $count;
+    public $total;
+    public $page;
+    public $pages;
+}

--- a/tests/TestCaseBase.php
+++ b/tests/TestCaseBase.php
@@ -95,6 +95,8 @@ class TestCaseBase extends TestCase
                         ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
                         DI\object('framework\system\FileListCommandStrategy')
                         ->constructor(DI\get('SlackFileManager'), DI\get('ISlackApi')),
+                        DI\object('framework\system\DeleteFileCommandStrategy')
+                        ->constructor(DI\get('SlackFileManager'), DI\get('ISlackApi')),
             ],
             'CommandStrategyFactory' => DI\factory(function($strategies)
             {

--- a/tests/TestCaseBase.php
+++ b/tests/TestCaseBase.php
@@ -61,6 +61,8 @@ class TestCaseBase extends TestCase
                     ->constructor(DI\get('CoreRepository'), DI\get('ConquestRepository'), DI\get('ZoneRepository'), DI\get('StrikeRepository'), DI\get('ISlackApi')),
             'ConquestManager' => DI\object('framework\conquest\ConquestManager')
                     ->constructor(DI\get('ConquestRepository'), DI\get('ZoneRepository'), DI\get('NodeRepository'), DI\get('StrikeRepository')),
+            'SlackFileManager' => DI\object('framework\system\SlackFileManager')
+                    ->constructor(DI\get('ISlackApi')),
             'framework\command\ICommandStrategy' => [
                         DI\object('framework\command\InitCommandStrategy')
                         ->constructor(DI\get('CoreRepository'), DI\get('ISlackApi')),
@@ -91,6 +93,8 @@ class TestCaseBase extends TestCase
                         ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
                         DI\object('framework\command\UserListCommandStrategy')
                         ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
+                        DI\object('framework\command\FileListCommandStrategy')
+                        ->constructor(DI\get('SlackFileManager'), DI\get('ISlackApi')),
             ],
             'CommandStrategyFactory' => DI\factory(function($strategies)
             {

--- a/tests/TestCaseBase.php
+++ b/tests/TestCaseBase.php
@@ -93,7 +93,7 @@ class TestCaseBase extends TestCase
                         ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
                         DI\object('framework\command\UserListCommandStrategy')
                         ->constructor(DI\get('UserRepository'), DI\get('ISlackApi')),
-                        DI\object('framework\command\FileListCommandStrategy')
+                        DI\object('framework\system\FileListCommandStrategy')
                         ->constructor(DI\get('SlackFileManager'), DI\get('ISlackApi')),
             ],
             'CommandStrategyFactory' => DI\factory(function($strategies)

--- a/tests/framework/CommandProcessorFactoryTest.php
+++ b/tests/framework/CommandProcessorFactoryTest.php
@@ -145,4 +145,11 @@ class CommandProcessorFactoryTest extends TestCaseBase
         $this->assertInstanceOf(\framework\command\SummaryHistoryCommandStrategy::class, $strategy);
     }
 
+    public function testDeleteFileCommandStrategy()
+    {
+        $message = $this->BuildJarvisMessage('file delete oldest 20');
+        
+        $strategy = $this->factory->GetCommandStrategy($message);
+        $this->assertInstanceOf(\framework\system\DeleteFileCommandStrategy::class, $strategy);
+    }
 }

--- a/tests/framework/system/DeleteFileCommandStrategyTest.php
+++ b/tests/framework/system/DeleteFileCommandStrategyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace tests\framework\system;
+
+use tests\TestCaseBase;
+
+/**
+ * Description of SlackFileManagerTest
+ *
+ * @author chris
+ */
+class DeleteFileCommandStrategyTest extends TestCaseBase
+{
+    private $command;
+    private $fileManagerMock;
+    private $slackApiMock;
+
+    protected function setUp()
+    {
+        $this->slackApiMock = $this->getMockBuilder(\framework\slack\SlackApi::class)
+                ->setMethods(['SendMessage'])
+                ->getMock();
+        $this->fileManagerMock = $this->getMockBuilder(\framework\system\SlackFileManager::class)
+                ->setMethods(['SetState'])
+                ->setConstructorArgs([$this->slackApiMock])
+                ->getMock();
+
+
+
+        $this->command = new \framework\system\DeleteFileCommandStrategy($this->fileManagerMock, $this->slackApiMock);
+    }
+
+    public function testTrainingodeOn()
+    {
+        $payload = array(
+            'channel' => 'ADFAS',
+            'text' => 'file delete oldest 20',
+        );
+        //$this->command->Process($payload);
+        //$this->command->SendResponse();
+    }
+
+}

--- a/tests/framework/system/SlackFileManagerTest.php
+++ b/tests/framework/system/SlackFileManagerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace tests\framework\system;
+
+use tests\TestCaseBase;
+use framework\system\SlackFileManager;
+use framework\slack\SlackApi;
+use DateTime;
+
+/**
+ * Description of SlackFileManagerTest
+ *
+ * @author chris
+ */
+class SlackFileManagerTest extends TestCaseBase
+{
+    private $slackApi;
+    private $manager;
+
+    protected function setUp()
+    {
+        $this->slackApi = new SlackApi();
+        $this->manager = new SlackFileManager($this->slackApi);
+    }
+/*
+    public function testFetchFileList()
+    {
+        $fileList = $this->manager->GetFileList();
+        var_dump($fileList);
+        //echo $fileList->paging;
+    }
+    
+    public function testFetchFileListBefore()
+    {
+        $dateTime = new DateTime();
+        $dateTime->modify('-3 month');
+        $this->manager->GetImagesListBefore($dateTime);
+    }
+ * 
+ */
+}


### PR DESCRIPTION
Slack team file storage has reached maximum, need to delete files quickly and easily.   Will only search for files older than 3 months and non-pinned and non-starred images.