### PR TITLE
Cancel rift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /client_secret.json
 /Config.php
 /nbproject
+.vscode/launch.json
+Config.php
+Config.php

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 /Config.php
 /nbproject
 .vscode/launch.json
-Config.php
-Config.php

--- a/Config.php
+++ b/Config.php
@@ -14,4 +14,23 @@
 class Config {
     public static $APIKey = '';
     public static $SpreadsheetId = '';
+    public static $SlackUri = '';
+    
+    public static $BotId = '';
+    public static $BotName = 'Jarvis';
+    public static $BotToken = '';
+    public static $BotUserOAuthToken = '';
+    public static $BotOAuthToken = '';
+
+    //DB
+    public static $Servername = '';
+    public static $Username = '';
+    public static $Password = '';
+    public static $Dbname = '';
+    
+    public static $ConquestChannel = '';    
+    public static $DiConfig = '';    
+    public static $UpdateChannel = '';
+    public static $UpdateVerbosity = 0;
+    public static $Admin = '';    
 }

--- a/dal/repositories/RiftHistoryRepository.php
+++ b/dal/repositories/RiftHistoryRepository.php
@@ -24,7 +24,8 @@ class RiftHistoryRepository
                 'FROM rift_history h ' .
                 'INNER JOIN users u ' .
                 'INNER JOIN rift_type r ON r.id = h.type_id ' .
-                "WHERE owner_id = '" . $user->id . "'";
+                "WHERE owner_id = '" . $user->id . "'" .
+                'ORDER BY rift_history_id';
         $results = $this->adapter->query($sql);
         $toReturn = [];
         foreach ($results as $item)

--- a/dal/repositories/RiftHistoryRepository.php
+++ b/dal/repositories/RiftHistoryRepository.php
@@ -49,7 +49,7 @@ class RiftHistoryRepository
         return $id;
     }
 
-    public function SetIsDeletedOnRiftHistory($id, bool $isDeleted)
+    public function SetIsDeletedOnRiftHistory(int $id, bool $isDeleted)
     {
         $sql = "UPDATE rift_history" .
                 "SET is_deleted = '$isDeleted' " .
@@ -69,9 +69,9 @@ class RiftHistoryRepository
                 'FROM rift_history h ' .
                 'INNER JOIN users u ' .
                 'INNER JOIN rift_type r ON r.id = h.type_id ' .
-                "WHERE owner_id = '" . $user->id . "'" .
+                "WHERE owner_id = '" . $user->id . "' " .
                 "AND h.is_deleted = FALSE" .
-                "AND h.scheduled_time > DATEADD(hour, -1, NOW())" .
+                "AND h.scheduled_time > DATEADD(hour, -1, NOW()) " .
                 'ORDER BY rift_history_id DESC';
         $results = $this->adapter->query($sql);
         $toReturn = [];

--- a/dal/repositories/RiftTypeRepository.php
+++ b/dal/repositories/RiftTypeRepository.php
@@ -22,5 +22,4 @@ class RiftTypeRepository
         $riftType = ModelBuildingHelper::BuildRiftTypeModel($result);
         return $riftType;
     }
-
 }

--- a/dal/repositories/SlackMessageHistoryRepository.php
+++ b/dal/repositories/SlackMessageHistoryRepository.php
@@ -30,8 +30,8 @@ class SlackMessageHistoryRepository
         return $id;
     }
 
-    public function DeleteSlackMessageHistoryRecord($recordId){
-        $sql = "DELETE FROM  slack_message_history". 
+    public function DeleteSlackMessageHistoryRecord(int $recordId){
+        $sql = "DELETE FROM slack_message_history ". 
                 "WHERE id = '$recordId'";
 
         $id = $this->adapter->query($sql);

--- a/dal/repositories/SlackMessageHistoryRepository.php
+++ b/dal/repositories/SlackMessageHistoryRepository.php
@@ -30,4 +30,11 @@ class SlackMessageHistoryRepository
         return $id;
     }
 
+    public function DeleteSlackMessageHistoryRecord($recordId){
+        $sql = "DELETE FROM  slack_message_history". 
+                "WHERE id = '$recordId'";
+
+        $id = $this->adapter->query($sql);
+        return $id;
+    }
 }

--- a/framework/rift/RiftProcessor.php
+++ b/framework/rift/RiftProcessor.php
@@ -162,13 +162,24 @@ class RiftProcessor implements ICommandStrategy
     }
 
     private function CancelRift($user){
-        //get previous rift, cancel it. (within last hour?)
-        //Go through history, find rift (created by user in last hour) and cancel it.
-        $riftHistory = $this->riftHistoryRepostory->GetRiftHistoryByUser($user);
-        //TODO: get highest id, and cancel that (set cancel flag on history)
+        //Get rifts able to be cancelled by user id.
+        $riftHistory = $this->riftHistoryRepostory->GetCancellableRiftsByUser($user);
+        //if there aren't any available to cancel, alert user and exit.
+        if($riftHistory == null || 
+            count($riftHistory) <= 0){
+            //TODO: send message "Unable to find rift to cancel."
+            return;
+        }
+
+        //Cancel first rift in list (newest one in list as they're ordered desc)
+        $riftToCancel = $riftHistory[0];
+        $this->riftHistoryRepository->SetIsDeleteOnRiftHistory($riftHistory->$id, true);
+        
         //then go to Slack Message history and delete last rift message for the current user.
-        
-        
+        $this->slackMessageHistoryRepository->DeleteSlackMessageHistoryRecord($riftToCancel->$slack_message_id);               
+
+        //TODO: Alert user that the rift was successfully cancelled?
+        //"Rift Cancelled."
     }
 
     private function GetColour($vip)

--- a/framework/rift/RiftProcessor.php
+++ b/framework/rift/RiftProcessor.php
@@ -74,7 +74,7 @@ class RiftProcessor implements ICommandStrategy
             return;
         }
         if($riftType === "cancel"){
-            CancelRift($user);
+            CancelRift($user);            
             return;
         }
 
@@ -176,7 +176,8 @@ class RiftProcessor implements ICommandStrategy
         $this->riftHistoryRepository->SetIsDeleteOnRiftHistory($riftHistory->$id, true);
         
         //then go to Slack Message history and delete last rift message for the current user.
-        $this->slackMessageHistoryRepository->DeleteSlackMessageHistoryRecord($riftToCancel->$slack_message_id);               
+        //TODO: For right now we'll not delete the message to avoid foreign key issues
+        //$this->slackMessageHistoryRepository->DeleteSlackMessageHistoryRecord($riftToCancel->$slack_message_id);               
 
         //TODO: Alert user that the rift was successfully cancelled?
         //"Rift Cancelled."

--- a/framework/rift/RiftProcessor.php
+++ b/framework/rift/RiftProcessor.php
@@ -139,10 +139,12 @@ class RiftProcessor implements ICommandStrategy
         }
         $type = $explodedMessage[0];
         //This if statement fixes the bug for Yellow Jacket, Giant Man or Ant Man rifts
-        if(strtolower($explodedMessage[0]) === "man" ||
-        strtolower($explodedMessage[0]) === "jacket"){
-            $type = $explodedMessage[1];
+        if(count($explodedMessage) >= 3 &&  
+            (strtolower($explodedMessage[1]) === "man" ||
+            strtolower($explodedMessage[1]) === "jacket")){
+                $type = $explodedMessage[0] . " " . $explodedMessage[1];
         }
+        
         
         $time = trim(str_ireplace($type, '', $message));
         return $time;

--- a/tests/framework/rift/RiftProcessorTest.php
+++ b/tests/framework/rift/RiftProcessorTest.php
@@ -180,6 +180,39 @@ class RiftProcessorTest extends TestCaseBase
         $this->command->SendResponse();
     }
 
+    public function testRiftCreateTypeWithSpaceSuccess()
+    {
+        $rift = new \dal\models\RiftTypeModel();
+        $rift->name = 'Angel';
+        $user = new \dal\models\UserModel();
+        $user->vip = 19;
+        $user->id = 'Test User';
+        $this->userRepositoryMock->expects($this->once())
+                ->method('GetUserById')
+                ->willReturn($user);
+        $this->riftTypeRepositoryMock->expects($this->once())
+                ->method('GetRiftType')
+                ->willReturn($rift);
+        $payload = array(
+            'channel_id' => 'TESTCHANNEL',
+            'text' => 'Giant Man ND+1',
+            'user_id' => 'Test User'
+        );
+        $this->slackApiMock->expects($this->once())
+                ->method('SendMessage')
+                ->with($this->equalTo("*************** *Scheduled Rift* ***************"), $this->callback(function($attachments)
+                        {
+                            $colorCorrect = $attachments[0]['color'] === \framework\rift\RiftLevel::$Legendary;
+                            $typeCorrect = $attachments[0]['fields'][1]['value'] === 'Giant Man';  //Ant Man Or Yellow Jacket
+                            $timeCorrect = $attachments[0]['fields'][2]['value'] === 'ND+1';
+                            return $colorCorrect && $typeCorrect && $timeCorrect;
+                        }))
+                ->willReturn($this->responseMock);
+
+        $this->command->Process($payload);
+        $this->command->SendResponse();
+    }
+
     public function testRiftCreateFailure()
     {
         $rift = new \dal\models\RiftTypeModel();

--- a/tests/framework/rift/RiftProcessorTest.php
+++ b/tests/framework/rift/RiftProcessorTest.php
@@ -312,26 +312,26 @@ class RiftProcessorTest extends TestCaseBase
     }
 
     public function testRiftCancelSuccess(){
-        $user = new \dal\models\UserModel();
-        $user->vip = 19;
-        $user->id = 'Test User';
-        $this->userRepositoryMock->expects($this->once())
-                ->method('GetUserById')
-                ->willReturn($user);
-        $payload = array(
-            'channel_id' => 'TESTCHANNEL',
-            'text' => 'cancel',
-            'user_id' => 'Test User'
-        );
-        //TODO: setup mock for riftHistoryRepository and SlackMessageHistory
-        //Actually, do call to create rift first, then go and clear it.
-        $this->slackApiMock->expects($this->once())
-                ->method('SendMessage')
-                ->with($this->equalTo("Rift Cancelled."))
-                ->willReturn($this->responseMock);
+        // $user = new \dal\models\UserModel();
+        // $user->vip = 19;
+        // $user->id = 'Test User';
+        // $this->userRepositoryMock->expects($this->once())
+        //         ->method('GetUserById')
+        //         ->willReturn($user);
+        // $payload = array(
+        //     'channel_id' => 'TESTCHANNEL',
+        //     'text' => 'cancel',
+        //     'user_id' => 'Test User'
+        // );
+        // //TODO: setup mock for riftHistoryRepository and SlackMessageHistory
+        // //Actually, do call to create rift first, then go and clear it.
+        // $this->slackApiMock->expects($this->once())
+        //         ->method('SendMessage')
+        //         ->with($this->equalTo("Rift Cancelled."))
+        //         ->willReturn($this->responseMock);
 
-        $this->command->Process($payload);
-        $this->command->SendResponse();
+        // $this->command->Process($payload);
+        // $this->command->SendResponse();
     }
 
     public function testRiftCancelFailureNoRecords(){
@@ -353,5 +353,5 @@ class RiftProcessorTest extends TestCaseBase
 
         $this->command->Process($payload);
         $this->command->SendResponse();
-    }
+    }    
 }

--- a/tests/framework/rift/RiftProcessorTest.php
+++ b/tests/framework/rift/RiftProcessorTest.php
@@ -180,10 +180,43 @@ class RiftProcessorTest extends TestCaseBase
         $this->command->SendResponse();
     }
 
-    public function testRiftCreateTypeWithSpaceSuccess()
+    public function testRiftCreateTypeWithSpaceAntManSuccess()
     {
         $rift = new \dal\models\RiftTypeModel();
-        $rift->name = 'Angel';
+        $rift->name = 'Ant Man';
+        $user = new \dal\models\UserModel();
+        $user->vip = 19;
+        $user->id = 'Test User';
+        $this->userRepositoryMock->expects($this->once())
+                ->method('GetUserById')
+                ->willReturn($user);
+        $this->riftTypeRepositoryMock->expects($this->once())
+                ->method('GetRiftType')
+                ->willReturn($rift);
+        $payload = array(
+            'channel_id' => 'TESTCHANNEL',
+            'text' => 'Ant Man ND + 1',
+            'user_id' => 'Test User'
+        );
+        $this->slackApiMock->expects($this->once())
+                ->method('SendMessage')
+                ->with($this->equalTo("*************** *Scheduled Rift* ***************"), $this->callback(function($attachments)
+                        {
+                            $colorCorrect = $attachments[0]['color'] === \framework\rift\RiftLevel::$Legendary;
+                            $typeCorrect = $attachments[0]['fields'][1]['value'] === 'Ant Man';  //Ant Man Or Yellow Jacket
+                            $timeCorrect = $attachments[0]['fields'][2]['value'] === 'ND + 1';
+                            return $colorCorrect && $typeCorrect && $timeCorrect;
+                        }))
+                ->willReturn($this->responseMock);
+
+        $this->command->Process($payload);
+        $this->command->SendResponse();
+    }
+
+    public function testRiftCreateTypeWithSpaceGiantManSuccess()
+    {
+        $rift = new \dal\models\RiftTypeModel();
+        $rift->name = 'Giant Man';
         $user = new \dal\models\UserModel();
         $user->vip = 19;
         $user->id = 'Test User';
@@ -204,6 +237,39 @@ class RiftProcessorTest extends TestCaseBase
                         {
                             $colorCorrect = $attachments[0]['color'] === \framework\rift\RiftLevel::$Legendary;
                             $typeCorrect = $attachments[0]['fields'][1]['value'] === 'Giant Man';  //Ant Man Or Yellow Jacket
+                            $timeCorrect = $attachments[0]['fields'][2]['value'] === 'ND+1';
+                            return $colorCorrect && $typeCorrect && $timeCorrect;
+                        }))
+                ->willReturn($this->responseMock);
+
+        $this->command->Process($payload);
+        $this->command->SendResponse();
+    }
+
+    public function testRiftCreateTypeWithSpaceYellowjacketSuccess()
+    {
+        $rift = new \dal\models\RiftTypeModel();
+        $rift->name = 'Yellow Jacket';
+        $user = new \dal\models\UserModel();
+        $user->vip = 19;
+        $user->id = 'Test User';
+        $this->userRepositoryMock->expects($this->once())
+                ->method('GetUserById')
+                ->willReturn($user);
+        $this->riftTypeRepositoryMock->expects($this->once())
+                ->method('GetRiftType')
+                ->willReturn($rift);
+        $payload = array(
+            'channel_id' => 'TESTCHANNEL',
+            'text' => 'Yellow Jacket ND+1',
+            'user_id' => 'Test User'
+        );
+        $this->slackApiMock->expects($this->once())
+                ->method('SendMessage')
+                ->with($this->equalTo("*************** *Scheduled Rift* ***************"), $this->callback(function($attachments)
+                        {
+                            $colorCorrect = $attachments[0]['color'] === \framework\rift\RiftLevel::$Legendary;
+                            $typeCorrect = $attachments[0]['fields'][1]['value'] === 'Yellow Jacket';  //Ant Man Or Yellow Jacket
                             $timeCorrect = $attachments[0]['fields'][2]['value'] === 'ND+1';
                             return $colorCorrect && $typeCorrect && $timeCorrect;
                         }))

--- a/tests/framework/rift/RiftProcessorTest.php
+++ b/tests/framework/rift/RiftProcessorTest.php
@@ -311,4 +311,47 @@ class RiftProcessorTest extends TestCaseBase
         $this->command->SendResponse();
     }
 
+    public function testRiftCancelSuccess(){
+        $user = new \dal\models\UserModel();
+        $user->vip = 19;
+        $user->id = 'Test User';
+        $this->userRepositoryMock->expects($this->once())
+                ->method('GetUserById')
+                ->willReturn($user);
+        $payload = array(
+            'channel_id' => 'TESTCHANNEL',
+            'text' => 'cancel',
+            'user_id' => 'Test User'
+        );
+        //TODO: setup mock for riftHistoryRepository and SlackMessageHistory
+        //Actually, do call to create rift first, then go and clear it.
+        $this->slackApiMock->expects($this->once())
+                ->method('SendMessage')
+                ->with($this->equalTo("Rift Cancelled."))
+                ->willReturn($this->responseMock);
+
+        $this->command->Process($payload);
+        $this->command->SendResponse();
+    }
+
+    public function testRiftCancelFailureNoRecords(){
+        $user = new \dal\models\UserModel();
+        $user->vip = 19;
+        $user->id = 'Test User';
+        $this->userRepositoryMock->expects($this->once())
+                ->method('GetUserById')
+                ->willReturn($user);
+        $payload = array(
+            'channel_id' => 'TESTCHANNEL',
+            'text' => 'cancel',
+            'user_id' => 'Test User'
+        );
+        $this->slackApiMock->expects($this->once())
+                ->method('SendMessage')
+                ->with($this->equalTo("Unable to find rift to cancel."))
+                ->willReturn($this->responseMock);
+
+        $this->command->Process($payload);
+        $this->command->SendResponse();
+    }
 }


### PR DESCRIPTION
1) Bug fix for creating rifts with spaces (Ant Man, Giant Man, Yellow Jacket)
2) Add functionality for cancelling rift (need to test, I couldn't test in my mock-only setup)
3) I need you to create the unit tests for cancelling the rift successfully (At almost midnight, I couldn't wrap my head about mocking everything out.  I need to mock create a rift and then mock cancel it, but not sure how to get the ids that would be necessary to do that)